### PR TITLE
Handle JUnit 3 tests

### DIFF
--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/GeneralTestClass.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/GeneralTestClass.scala
@@ -24,6 +24,8 @@ object GeneralTestClass {
 
                 Try(if (methods.exists(_.getAnnotation(testAnnotation) != null)) {
                     Option(new JUnitTestClass(loader, clz))
+                } else if (loader.loadClass("junit.framework.TestCase").isAssignableFrom(clz)) {
+                    Option(new JUnitTestCaseClass(loader, clz))
                 } else {
                     Option.empty
                 }).toOption.flatten

--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/JUnitTestCaseClass.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/JUnitTestCaseClass.scala
@@ -1,0 +1,14 @@
+package edu.illinois.cs.testrunner.testobjects
+
+import java.lang.reflect.Method
+
+class JUnitTestCaseClass(loader : ClassLoader, clz: Class[_]) extends GeneralTestClass {
+
+    def fullyQualifiedName(m: Method): String =
+        clz.getCanonicalName ++ "." ++ m.getName
+
+    override def tests(): Stream[String] = {
+        clz.getDeclaredMethods().toStream
+            .filter(_.getName().startsWith("test")).map(fullyQualifiedName)
+    }
+}


### PR DESCRIPTION
This pull request proposes new logic for testrunner to locate JUnit 3 test methods, which are methods that start with "test" and are in a class that is a subclass from TestCase.