### PR TITLE
Get All Methods for JUnit 5 Class

### DIFF
--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/data/framework/TestFramework.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/data/framework/TestFramework.scala
@@ -4,6 +4,7 @@ import edu.illinois.cs.testrunner.testobjects.GeneralTestClass
 import edu.illinois.cs.testrunner.testobjects.JUnitTestCaseClass
 import edu.illinois.cs.testrunner.testobjects.JUnitTestClass
 import edu.illinois.cs.testrunner.testobjects.JUnit5TestClass
+import edu.illinois.cs.testrunner.util.Utility
 import org.apache.maven.project.MavenProject
 import java.lang.annotation.Annotation
 import java.lang.reflect.Modifier
@@ -115,7 +116,7 @@ object JUnit5 extends TestFramework {
             val clz = loader.loadClass(clzName)
 
             if (!Modifier.isAbstract(clz.getModifiers)) {
-                val methods = clz.getMethods.toStream
+                val methods = Utility.getAllMethods(clz)
 
                 Try(if (methods.exists(_.getAnnotation(annotation) != null)) {
                     Option(new JUnit5TestClass(loader, clz))

--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/JUnit5TestClass.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/JUnit5TestClass.scala
@@ -1,5 +1,6 @@
 package edu.illinois.cs.testrunner.testobjects
 
+import edu.illinois.cs.testrunner.util.Utility
 import java.lang.annotation.Annotation
 import java.lang.reflect.Method
 
@@ -13,8 +14,8 @@ class JUnit5TestClass(loader: ClassLoader, clz: Class[_]) extends GeneralTestCla
     override def tests(): Stream[String] = {
         val junit5TestAnnotation: Class[_ <: Annotation] =
             loader.loadClass("org.junit.jupiter.api.Test").asInstanceOf[Class[_ <: Annotation]]
-        clz.getDeclaredMethods().toStream
-                .filter(_.getAnnotation(junit5TestAnnotation) != null)
-                .map(fullyQualifiedName)
+        Utility.getAllMethods(clz)
+               .filter(_.getAnnotation(junit5TestAnnotation) != null)
+               .map(fullyQualifiedName)
     }
 }

--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/util/Utility.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/util/Utility.scala
@@ -1,9 +1,29 @@
 package edu.illinois.cs.testrunner.util
 
+import java.lang.reflect.Method;
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneId}
+import scala.collection.mutable.HashSet
+import scala.collection.mutable.ListBuffer
 
 object Utility {
     def timestamp(): String =
         DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss").format(Instant.now().atZone(ZoneId.systemDefault()))
+
+    def getAllMethods(clz: Class[_]): Stream[Method] = {
+        var curClz = clz;
+        val methods = new ListBuffer[Method]()
+        val nameSet = HashSet[String]()
+        while (curClz != null) {
+            for (m <- curClz.getDeclaredMethods) {
+                if (!nameSet.contains(m.getName)) {
+                    // exclude override method
+                    methods.append(m)
+                    nameSet.add(m.getName)
+                }
+            }
+            curClz = curClz.getSuperclass
+        }
+        methods.toStream
+    }
 }


### PR DESCRIPTION
Unlike JUnit 4 tests, which must be public, JUnit 5 tests can be
non-public (package-private). While getMethods function only
returns public methods, leading to failure of finding JUnit 5 tests.

Change getMethods to getDeclaredMethods so that we can get all
methods of a test class.

Also, call getDeclaredMethods of superclass iteratively to
get all the inherited methods.