### PR TITLE
Build correct fullyQualifiedName for nested test

### DIFF
--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/execution/Utils.java
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/execution/Utils.java
@@ -4,8 +4,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Utils {
-    private static final String junit5Regex = "\\[class:([\\w.]+).*\\[method:(\\w+)\\(";
-    private static final Pattern junit5Pattern = Pattern.compile(junit5Regex);
+    private static final String junit5BasicRegex = "\\[class:([\\w.]+).*\\[method:([\\w().]+)";
+    private static final Pattern junit5BasicPattern = Pattern.compile(junit5BasicRegex);
+    private static final String junit5NestedRegex = "\\[nested-class:([\\w.]+)\\]";
+    private static final Pattern junit5NestedPattern = Pattern.compile(junit5NestedRegex);
     private static final String junit4Regex = "\\[test:(\\w+)\\(([\\w.]+)\\)";
     private static final Pattern junit4Pattern = Pattern.compile(junit4Regex);
 
@@ -14,17 +16,34 @@ public class Utils {
      *
      * For JUnit 5:
      * uniqueId: [engine:junit-jupiter]/[class:com.luojl.demo.JUnit5DemoTest]/[method:TestC()]
-     * full qualified name: com.luojl.demo.JUnit5DemoTest#TestC
+     * full qualified name: com.luojl.demo.JUnit5DemoTest#TestC()
+     *
+     * For JUnit 5 nested test:
+     * uniqueId: [engine:junit-jupiter]/[class:com.luojl.demo.InheritedTest]/[nested-class:NestedTest]/[method:NestedTestB()]
+     * fully qualified name: com.luojl.demo.InheritedTest$NestedTest#NestedTestB()
      *
      * For JUnit 4:
      * uniqueId: [engine:junit-vintage]/[runner:com.luojl.demo.JUnit4DemoTest]/[test:TestA4(com.luojl.demo.JUnit4DemoTest)]
      * full qualified name: com.luojl.demo.JUnit4DemoTest#TestA4
      */
     public static String toFullyQualifiedName(String identifierUniqueId) {
-        Matcher matcher = junit5Pattern.matcher(identifierUniqueId);
+        Matcher matcher = junit5BasicPattern.matcher(identifierUniqueId);
         if (matcher.find()) {
-            // found JUnit 5 pattern
-            return matcher.group(1) + "#" + matcher.group(2);
+            // found JUnit 5 basic pattern: class + method
+            StringBuilder sb = new StringBuilder();
+            sb.append(matcher.group(1));  // com.package.ClassName
+
+            Matcher nestedMatcher = junit5NestedPattern.matcher(identifierUniqueId);
+            while (nestedMatcher.find()) {
+                // found nested class
+                // may nest multiple layers
+                sb.append("$");
+                sb.append(nestedMatcher.group(1));
+            }
+
+            sb.append("#");
+            sb.append(matcher.group(2));  // method
+            return sb.toString();
         }
         // fall back to JUnit 4
         matcher = junit4Pattern.matcher(identifierUniqueId);

--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/JUnit5TestClass.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/JUnit5TestClass.scala
@@ -9,7 +9,7 @@ import scala.collection.JavaConverters._
 class JUnit5TestClass(loader: ClassLoader, clz: Class[_]) extends GeneralTestClass {
 
     def fullyQualifiedName(method: Method): String =
-        clz.getCanonicalName ++ "#" ++ method.getName
+        clz.getName ++ "#" ++ method.getName
 
     override def tests(): Stream[String] = {
         val junit5TestAnnotation: Class[_ <: Annotation] =

--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/JUnitTestClass.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/JUnitTestClass.scala
@@ -10,7 +10,7 @@ class JUnitTestClass(loader: ClassLoader, clz: Class[_]) extends GeneralTestClas
     private def junitTestClass: TestClass = new TestClass(clz)
 
     def fullyQualifiedName(fm: FrameworkMethod): String =
-        clz.getCanonicalName ++ "." ++ fm.getName
+        clz.getName ++ "." ++ fm.getName
 
     override def tests(): Stream[String] = {
         val testAnnotation: Class[_ <: Annotation] =


### PR DESCRIPTION
For a nested test the correct fully qualified name should be:
com.package.ClassA$NestedClassB#TestC     pay attention to $

In this case, the Class.getName returns: com.package.ClassA$NestedClassB
While Class.getCanonicalName return: com.package.ClassA.NestedClassB (wrong)

Also, add a regex to parse the nested test uniqueId.