### PR TITLE
Correct name for @Test method with parameters

### DIFF
--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/JUnit5TestClass.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/testobjects/JUnit5TestClass.scala
@@ -8,8 +8,10 @@ import scala.collection.JavaConverters._
 
 class JUnit5TestClass(loader: ClassLoader, clz: Class[_]) extends GeneralTestClass {
 
-    def fullyQualifiedName(method: Method): String =
-        clz.getName ++ "#" ++ method.getName
+    def fullyQualifiedName(method: Method): String = {
+        val paramsStr = method.getParameterTypes.map(c => c.getName).mkString(",")
+        clz.getName ++ "#" ++ method.getName ++ "(" ++ paramsStr ++ ")"
+    }
 
     override def tests(): Stream[String] = {
         val junit5TestAnnotation: Class[_ <: Annotation] =


### PR DESCRIPTION
For `@Test` method with parameters, the correct fully qualifed name
is like: com.package.Class#method(java.lang.String, ...).

So add the parameters list string when building fully qualified name
for `@Test` methods.