### PR TITLE
Making getParent() return null if parent actually is null

### DIFF
--- a/testrunner-maven-plugin/src/main/scala/edu/illinois/cs/testrunner/mavenplugin/MavenProjectWrapper.java
+++ b/testrunner-maven-plugin/src/main/scala/edu/illinois/cs/testrunner/mavenplugin/MavenProjectWrapper.java
@@ -42,6 +42,9 @@ public class MavenProjectWrapper implements ProjectWrapper {
     }
 
     public MavenProjectWrapper getParent() {
+        if (project.getParent() == null) {
+            return null;
+        }
         return new MavenProjectWrapper(project.getParent(), logger);
     }
 


### PR DESCRIPTION
Currently, if the parent of the Maven project is null (meaning it is already at the root), it still creates a new, non-null MavenProjectWrapper that contains that null instance. However, downstream projects such as iDFlakies assumes that getParent() returns a non-null instance then there are further parents to go. Running iDFlakies with this current logic in testrunner makes it throw a NullPointerException when it tries to access the top-most parent, e.g., when looking for the top-most mvn-test-time.log, because it thinks it can go one higher.

This change makes it return null when there are no more parents.

I suggest that we also make a minor release with this bug fix, e.g., 1.2.1, for the sake of downstream projects.