### PR TITLE
Changing TestResult to store Strings instead of StackTraceElements

### DIFF
--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/data/results/TestResult.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/data/results/TestResult.scala
@@ -1,3 +1,3 @@
 package edu.illinois.cs.testrunner.data.results
 
-case class TestResult(name: String, result: Result, time: Double, stackTrace: Array[StackTraceElement])
+case class TestResult(name: String, result: Result, time: Double, stackTrace: Array[String])

--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/data/results/TestResultFactory.java
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/data/results/TestResultFactory.java
@@ -10,15 +10,15 @@ public class TestResultFactory {
     }
 
     public static TestResult passing(final double time, final String testName) {
-        return new TestResult(testName, Result.PASS, time, new StackTraceElement[0]);
+        return new TestResult(testName, Result.PASS, time, new String[0]);
     }
 
     public static TestResult missing(final String testName) {
-        return new TestResult(testName, Result.SKIPPED, -1, new StackTraceElement[0]);
+        return new TestResult(testName, Result.SKIPPED, -1, new String[0]);
     }
 
     public static TestResult ignored(final String fullMethodName) {
-        return new TestResult(fullMethodName, Result.SKIPPED, -1, new StackTraceElement[0]);
+        return new TestResult(fullMethodName, Result.SKIPPED, -1, new String[0]);
     }
 
     public static TestResult failOrError(final Throwable throwable, final double time, final String testName) {
@@ -30,6 +30,11 @@ public class TestResultFactory {
             result = Result.ERROR;
         }
 
-        return new TestResult(testName, result, time, throwable.getStackTrace());
+        StackTraceElement[] stackTrace = throwable.getStackTrace();
+        String[] stackTraceStrings = new String[stackTrace.length];
+        for (int i = 0; i < stackTrace.length; i++) {
+            stackTraceStrings[i] = stackTrace[i].toString();
+        }
+        return new TestResult(testName, result, time, stackTraceStrings);
     }
 }


### PR DESCRIPTION
This pull request changes the TestResult class to store an array of Strings representing the stack trace instead of the actual `StackTraceElement` objects. We don't seem to use the actual `StackTraceElement` objects, as we are mainly just serializing them into logs. Further, later versions of Java, namely JDK 17, seem to not allow easy serialization of `StackTraceElement`, so it would be better off to store them as Strings immediately for later serialization.