### PR TITLE
Distinguish methods

### DIFF
--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/util/Utility.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/util/Utility.scala
@@ -16,10 +16,12 @@ object Utility {
         val nameSet = HashSet[String]()
         while (curClz != null) {
             for (m <- curClz.getDeclaredMethods) {
-                if (!nameSet.contains(m.getName)) {
+                val paramsStr = m.getParameterTypes.map(c => c.getName).mkString(",")
+                val methodName = m.getName ++ "(" ++ paramsStr ++ ")"
+                if (!nameSet.contains(methodName)) {
                     // exclude override method
                     methods.append(m)
-                    nameSet.add(m.getName)
+                    nameSet.add(methodName)
                 }
             }
             curClz = curClz.getSuperclass

--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/util/Utility.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/util/Utility.scala
@@ -19,7 +19,7 @@ object Utility {
                 val paramsStr = m.getParameterTypes.map(c => c.getName).mkString(",")
                 val methodName = m.getName ++ "(" ++ paramsStr ++ ")"
                 if (!nameSet.contains(methodName)) {
-                    // exclude override method
+                    // exclude overridden method
                     methods.append(m)
                     nameSet.add(methodName)
                 }


### PR DESCRIPTION
This pull request changes the functionality of `Utility.getAllMethods` to track duplicate methods based off of the whole signature (method name and parameter names) instead of just the method name, in case some classes have overloaded method names.

Addresses part of the concern in https://github.com/UT-SE-Research/iDFlakies/issues/51