### PR TITLE
Introducing a way to configure additional Java options

### DIFF
--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/runner/Runner.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/runner/Runner.scala
@@ -12,6 +12,7 @@ import edu.illinois.cs.testrunner.execution.Executor
 import edu.illinois.cs.testrunner.util._
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 import scala.io.Source
 import scala.util.{Failure, Try}
 
@@ -38,6 +39,13 @@ trait Runner {
         if (Configuration.config().getProperty(ConfigProps.CAPTURE_STATE, false)) {
             builder.javaAgent(Paths.get(Configuration.config().getProperty("testplugin.javaagent")))
         }
+
+        val javaopts = Configuration.config().getProperty("testplugin.javaopts").split(",")
+        val javaoptsList = new ListBuffer[String]()
+        for (opt <- javaopts) {
+            javaoptsList += opt
+        }
+        builder.javaOpts(javaoptsList.toList)
 
         builder.environment(environment())
     }

--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/runner/Runner.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/runner/Runner.scala
@@ -40,7 +40,7 @@ trait Runner {
             builder.javaAgent(Paths.get(Configuration.config().getProperty("testplugin.javaagent")))
         }
 
-        val javaopts = Configuration.config().getProperty("testplugin.javaopts").split(",")
+        val javaopts = Configuration.config().getProperty("testplugin.javaopts", "").split(",")
         val javaoptsList = new ListBuffer[String]()
         for (opt <- javaopts) {
             javaoptsList += opt

--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/runner/Runner.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/runner/Runner.scala
@@ -40,12 +40,16 @@ trait Runner {
             builder.javaAgent(Paths.get(Configuration.config().getProperty("testplugin.javaagent")))
         }
 
-        val javaopts = Configuration.config().getProperty("testplugin.javaopts", "").split(",")
-        val javaoptsList = new ListBuffer[String]()
-        for (opt <- javaopts) {
-            javaoptsList += opt
+        if (!Configuration.config().getProperty("testplugin.javaopts", "").equals("")) {
+            val javaopts = Configuration.config().getProperty("testplugin.javaopts", "").split(",")
+            val javaoptsList = new ListBuffer[String]()
+            for (opt <- javaopts) {
+                javaoptsList += opt
+            }
+            if (!javaoptsList.isEmpty) {
+                builder.javaOpts(javaoptsList.toList)
+            }
         }
-        builder.javaOpts(javaoptsList.toList)
 
         builder.environment(environment())
     }


### PR DESCRIPTION
Currently, the testrunner can pass in additional Java options to the process it starts when running tests, but strangely there does not seem to be a means to configure said options from the command line. This pull request attempts to introduce some flag to pass in additional Java options from the command line. The idea is to use the flag `-Dtestplugin.javaopts` to pass in a comma-delimited sequence of additional flags (each flag is something like `-Dflag=value`) so they can be passed to the process that runs tests. This current way of passing in flags may be a bit clunky, so I'm open to any suggestions of other ways to approach this.